### PR TITLE
Add jesd204c support

### DIFF
--- a/jesd_common.h
+++ b/jesd_common.h
@@ -54,6 +54,8 @@
 
 #define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
 
+#define        JESD204_ENCODER_8B10B   0
+#define        JESD204_ENCODER_64B66B  1
 
 struct jesd204b_laneinfo {
 	unsigned did;		/* DID Device ID */
@@ -86,6 +88,7 @@ struct jesd204b_laneinfo {
 	char cgs_state[MAX_SYSFS_STRING_SIZE];
 	char init_frame_sync[MAX_SYSFS_STRING_SIZE];
 	char init_lane_align_seq[MAX_SYSFS_STRING_SIZE];
+	char ext_multiblock_align_state[MAX_SYSFS_STRING_SIZE];
 };
 
 struct jesd204b_xcvr_eyescan_info {
@@ -123,5 +126,6 @@ int read_all_laneinfo(const char *path,
 		      struct jesd204b_laneinfo lane_info[MAX_LANES]);
 int read_jesd204_status(const char *basedir,
 			struct jesd204b_jesd204_status *info);
+int read_encoding(const char *basedir);
 
 #endif

--- a/jesd_status.c
+++ b/jesd_status.c
@@ -460,6 +460,7 @@ int main(int argc, char *argv[])
 		}
 
 		wrefresh(stat_win);
+		usleep(1000 * 100);
 
 		c = getch();
 		if (c >= KEY_F(1) && c <= KEY_F0 + dev_num) {
@@ -484,7 +485,6 @@ int main(int argc, char *argv[])
 		} else if (c == KEY_F0 + MAX_DEVICES + 1 || c == 'q')
 			break;
 
-		sleep(1);
 	}
 
 	terminal_stop();


### PR DESCRIPTION
The first patches do a bit of refactor/enhancement to the tool. The biggest change is that, now the tool displays information per device and the user can move between devices. This makes it easier to integrate different labels (for jes204c) and can potentially fix some issues (not sure if 2 rx devices with 16 lanes would display correctly...).