### PR TITLE
jesd_status minor tweaks

### DIFF
--- a/jesd_common.c
+++ b/jesd_common.c
@@ -56,22 +56,24 @@ char *get_full_device_path(const char *basedir, const char *device)
 	return path;
 }
 
-int jesd_find_devices(const char *basedir, const char *name,
-		      char devices[MAX_DEVICES][PATH_MAX])
+int jesd_find_devices(const char *basedir, const char *driver,
+		      char devices[MAX_DEVICES][PATH_MAX], int start)
 {
 	struct dirent *de;
-	DIR *dr = opendir(basedir);
-	int num = 0;
+	char path[PATH_MAX];
+	DIR *dr;
+	int num = start;
 
+	snprintf(path, sizeof(path), "%s/%s", basedir, driver);
+	dr = opendir(path);
 	if (dr == NULL) {
 		fprintf(stderr, "Could not open current directory\n");
 		return 0;
 	}
 
 	while ((de = readdir(dr)) != NULL)
-		if (strstr(de->d_name, name) && num < MAX_DEVICES) {
-			strncpy((char *)&devices[num], de->d_name,
-				sizeof(devices[num]));
+		if (de->d_type == DT_LNK && num < MAX_DEVICES) {
+			snprintf((char *)&devices[num], PATH_MAX, "%s/%s", driver, de->d_name);
 			num++;
 		}
 

--- a/jesd_common.c
+++ b/jesd_common.c
@@ -64,7 +64,7 @@ int jesd_find_devices(const char *basedir, const char *name,
 	int num = 0;
 
 	if (dr == NULL) {
-		fprintf(stderr, "Could not open current directory");
+		fprintf(stderr, "Could not open current directory\n");
 		return 0;
 	}
 

--- a/jesd_common.h
+++ b/jesd_common.h
@@ -59,6 +59,10 @@
 #define        JESD204_ENCODER_8B10B   0
 #define        JESD204_ENCODER_64B66B  1
 
+#define JESD204_RX_DRIVER_NAME	"axi-jesd204-rx"
+#define JESD204_TX_DRIVER_NAME	"axi-jesd204-tx"
+#define XCVR_DRIVER_NAME	"axi_adxcvr_drv"
+
 struct jesd204b_laneinfo {
 	unsigned did;		/* DID Device ID */
 	unsigned bid;		/* BID Bank ID */
@@ -120,8 +124,8 @@ struct jesd204b_jesd204_status {
 };
 
 char *get_full_device_path(const char *basedir, const char *device);
-int jesd_find_devices(const char *basedir, const char *name,
-		      char devices[MAX_DEVICES][PATH_MAX]);
+int jesd_find_devices(const char *basedir, const char *drvname,
+		      char devices[MAX_DEVICES][PATH_MAX], int start);
 int read_laneinfo(const char *basedir, unsigned lane,
 		  struct jesd204b_laneinfo *info);
 int read_all_laneinfo(const char *path,

--- a/jesd_eye_scan.c
+++ b/jesd_eye_scan.c
@@ -263,11 +263,11 @@ static GtkWidget *create_view_and_model(unsigned active_lanes)
 	return view;
 }
 
-int get_devices(const char *path, const char *device, GtkWidget *device_select)
+int get_devices(const char *path, const char *driver, GtkWidget *device_select)
 {
 	int dev_num, i;
 
-	dev_num = jesd_find_devices(path, device, jesd_devices);
+	dev_num = jesd_find_devices(path, driver, jesd_devices, 0);
 
 	for (i = 0; i < dev_num; i++)
 		gtk_combo_box_text_append_text(GTK_COMBO_BOX_TEXT(device_select),
@@ -1137,7 +1137,7 @@ int main(int argc, char *argv[])
 		path = "";
 	}
 
-	ret = snprintf(basedir, sizeof(basedir), "%s/sys/bus/platform/devices", path);
+	ret = snprintf(basedir, sizeof(basedir), "%s/sys/bus/platform/drivers", path);
 
 	if (ret < 0) {
 		return EXIT_FAILURE;
@@ -1244,8 +1244,9 @@ int main(int argc, char *argv[])
 	g_signal_connect(G_OBJECT(main_window), "destroy",
 	                 G_CALLBACK(gtk_main_quit), NULL);
 
-	get_devices(basedir, XCVR_DEVICE_NAME, device_select);
-	get_devices(basedir, JESD204_DEVICE_NAME, jesd_core_selection);
+	get_devices(basedir, XCVR_DRIVER_NAME, device_select);
+	get_devices(basedir, JESD204_RX_DRIVER_NAME, jesd_core_selection);
+	get_devices(basedir, JESD204_TX_DRIVER_NAME, jesd_core_selection);
 
 	logo = GTK_IMAGE(gtk_builder_get_object(builder, "logo"));
 

--- a/jesd_status.c
+++ b/jesd_status.c
@@ -50,9 +50,6 @@
 
 #include "jesd_common.h"
 
-#define JESD204_DEVICE_NAME 	"jesd204"
-#define XCVR_DEVICE_NAME 	"adxcvr"
-
 #define COL_SPACEING 3
 
 enum color_pairs {
@@ -419,9 +416,10 @@ int main(int argc, char *argv[])
 	if (!path)
 		path = "";
 
-	snprintf(basedir, sizeof(basedir), "%s/sys/bus/platform/devices", path);
+	snprintf(basedir, sizeof(basedir), "%s/sys/bus/platform/drivers", path);
 
-	dev_num = jesd_find_devices(basedir, JESD204_DEVICE_NAME, jesd_devices);
+	dev_num = jesd_find_devices(basedir, JESD204_RX_DRIVER_NAME, jesd_devices, 0);
+	dev_num = jesd_find_devices(basedir, JESD204_TX_DRIVER_NAME, jesd_devices, dev_num);
 	if (!dev_num) {
 		fprintf(stderr, "Failed to find JESD devices\n");
 		return 0;

--- a/jesd_status.c
+++ b/jesd_status.c
@@ -423,7 +423,7 @@ int main(int argc, char *argv[])
 
 	dev_num = jesd_find_devices(basedir, JESD204_DEVICE_NAME, jesd_devices);
 	if (!dev_num) {
-		fprintf(stderr, "Failed to find JESD devices");
+		fprintf(stderr, "Failed to find JESD devices\n");
 		return 0;
 	}
 

--- a/jesd_status.c
+++ b/jesd_status.c
@@ -382,19 +382,24 @@ static void jesd_move_device(const int old_idx, const int new_idx,
 int main(int argc, char *argv[])
 {
 	int c, cnt = 0, x = 1, i, simple = 0;
+	int up_key = 'a', down_key = 'd';
 	int termx, termy, dev_num = 0;
 	char *path = NULL;
 	int dev_idx = 0;
 
 	opterr = 0;
 
-	while ((c = getopt(argc, argv, "sp:")) != -1)
+	while ((c = getopt(argc, argv, "svp:")) != -1)
 		switch (c) {
 		case 'p':
 			path = optarg;
 			break;
 		case 's': /* Simple mode */
 			simple = 1;
+			break;
+		case 'v':
+			up_key = 'k';
+			down_key = 'j';
 			break;
 		case '?':
 			if (optopt == 'd' || optopt == 'p')
@@ -509,7 +514,7 @@ int main(int argc, char *argv[])
 			int old_idx = dev_idx;
 			dev_idx = c - KEY_F0 - 1;
 			jesd_move_device(old_idx, dev_idx, simple);
-		} else if (c == 'd') {
+		} else if (c == down_key) {
 			int old_idx = dev_idx;
 
 			if (dev_idx + 1 >= dev_num)
@@ -517,7 +522,7 @@ int main(int argc, char *argv[])
 			else
 				dev_idx++;
 			jesd_move_device(old_idx, dev_idx, simple);
-		} else if (c == 'a') {
+		} else if (c == up_key) {
 			int old_idx = dev_idx;
 			if (!dev_idx)
 				dev_idx = dev_num - 1;


### PR DESCRIPTION
Hi, 

Here are minor tweaks to `jesd_status` that I have locally and that thought I'd send back.
The interesting change is the commit renaming JESD204 devices.

By default, Vivado exports TPL cores with jesd in their name causing them to appear in the list of devices resulting in something like this:
![image](https://user-images.githubusercontent.com/3811160/91098268-2d889a80-e62f-11ea-87f9-af338b47f3cf.png)
