### PR TITLE
jesd_status: Support for optional device clock status information

### DIFF
--- a/jesd_common.c
+++ b/jesd_common.c
@@ -215,6 +215,13 @@ int read_all_laneinfo(const char *path, struct jesd204b_laneinfo lane_info[MAX_L
 	return cnt;
 }
 
+void set_not_availabe(char *str)
+{
+	str[0] = 'N';
+	str[1] = '/';
+	str[2] = 'A';
+	str[3] = 0;
+}
 
 int read_jesd204_status(const char *basedir,
 			struct jesd204b_jesd204_status *info)
@@ -245,6 +252,22 @@ int read_jesd204_status(const char *basedir,
 		     (char *)&info->measured_link_clock);
 	ret = fscanf(pFile, "Reported Link Clock: %s MHz\n",
 		     (char *)&info->reported_link_clock);
+
+	pos = ftell(pFile);
+	ret = fscanf(pFile, "Measured Device Clock: %s MHz\n",
+		     (char *)&info->measured_device_clock);
+
+	if (ret == 1) {
+		ret = fscanf(pFile, "Reported Device Clock: %s MHz\n",
+			(char *)&info->reported_device_clock);
+		ret = fscanf(pFile, "Desired Device Clock: %s MHz\n",
+			(char *)&info->desired_device_clock);
+	} else {
+		set_not_availabe(info->measured_device_clock);
+		set_not_availabe(info->reported_device_clock);
+		set_not_availabe(info->desired_device_clock);
+		fseek(pFile, pos, SEEK_SET);
+	}
 
 	pos = ftell(pFile);
 	ret = fscanf(pFile, "Lane rate: %s MHz\n", (char *)&info->lane_rate);

--- a/jesd_common.h
+++ b/jesd_common.h
@@ -56,8 +56,8 @@
 #define MAX(a,b) (((a)>(b))?(a):(b))
 #define MIN(a,b) (((a)<(b))?(a):(b))
 
-#define        JESD204_ENCODER_8B10B   0
-#define        JESD204_ENCODER_64B66B  1
+#define JESD204_ENCODER_8B10B   0
+#define JESD204_ENCODER_64B66B  1
 
 #define JESD204_RX_DRIVER_NAME	"axi-jesd204-rx"
 #define JESD204_TX_DRIVER_NAME	"axi-jesd204-tx"
@@ -113,6 +113,9 @@ struct jesd204b_jesd204_status {
 	char link_state[MAX_SYSFS_STRING_SIZE];
 	char measured_link_clock[MAX_SYSFS_STRING_SIZE];
 	char reported_link_clock[MAX_SYSFS_STRING_SIZE];
+	char measured_device_clock[MAX_SYSFS_STRING_SIZE];
+	char reported_device_clock[MAX_SYSFS_STRING_SIZE];
+	char desired_device_clock[MAX_SYSFS_STRING_SIZE];
 	char lane_rate[MAX_SYSFS_STRING_SIZE];
 	char lane_rate_div[MAX_SYSFS_STRING_SIZE];
 	char lmfc_rate[MAX_SYSFS_STRING_SIZE];


### PR DESCRIPTION
Starting with AXI-JESD204-RX (1.07.a) and AXI-JESD204-TX (1.06.a)
and Linux v5.4. The axi_jesd_[rx|tx] driver will emit additional lines.
This commit handles them correctly.

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>