### PR TITLE
make: create .config/autostart folder

### DIFF
--- a/makefile
+++ b/makefile
@@ -22,6 +22,7 @@ install:
 	install ./jesd_eye_scan_autostart.sh $(DESTDIR)/bin/
 	install ./jesd.glade $(DESTDIR)/share/jesd/
 	install ./icons/ADIlogo.png $(DESTDIR)/share/jesd/
+	mkdir -p ${HOME}/.config/autostart
 	install jesd_eye_scan.desktop $(HOME)/.config/autostart/jesd_eye_scan.desktop
 
 clean:


### PR DESCRIPTION
The 'make install' command is failing with "No such file
or directory" message because ./config/autostart folder
doesn't exists in $HOME. Use option '-p' on 'mkdir' to
not output anything even if the folder already exists.

Signed-off-by: stefan.raus <stefan.raus@analog.com>