### PR TITLE
Make format string a string literal

### DIFF
--- a/jesd_status.c
+++ b/jesd_status.c
@@ -179,7 +179,7 @@ int jesd_print_win(WINDOW *win, int y, int x, enum color_pairs c,
 		jesd_clear_line_from(win, y, x);
 
 	wcolor_set(win, c, NULL);
-	mvwprintw(win, y, x, str);
+	mvwprintw(win, y, x, "%s", str);
 	wcolor_set(win, C_NORM, NULL);
 
 	return jesd_get_strlen(win, x);
@@ -359,7 +359,7 @@ int jesd_setup_subwin(WINDOW *win, const char *name, const char **labels)
 {
 	int i = 0, pos = 0;
 
-	mvwprintw(win, 0, 1, name);
+	mvwprintw(win, 0, 1, "%s", name);
 
 	while (labels[i]) {
 		pos = jesd_maxx(pos, jesd_print_win(win, i + 1, 1, C_NORM, labels[i], false));


### PR DESCRIPTION
Non string literal format strings result in a compile error when using yocto/openembedded's security flags since they include "-Werror=format-security".

Fixes compile error:
```
| aarch64-xilinx-linux-gcc  -mcpu=cortex-a72.cortex-a53 -march=armv8-a+crc -Wl,-O1 -Wl,--hash-style=gnu -Wl,--as-needed [<redacted>] -Wl,-z,relro,-z,now -fstack-protector-strong  -O2 -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security --sysroot=/home/peta/[<redacted>]/build/tmp/work/cortexa72-cortexa53-xilinx-linux/jesd-status/dev-r0/recipe-sysroot -g -O2 -Wall -Wl,--export-dynamic   -c -o jesd_status.o jesd_status.c 
| jesd_status.c:182:9: error: format not a string literal and no format arguments [-Werror=format-security] 
|   182 |         mvwprintw(win, y, x, str); 
|       |         ^~~~~~~~~ 
| jesd_status.c: In function 'jesd_setup_subwin': 
| jesd_status.c:362:9: error: format not a string literal and no format arguments [-Werror=format-security] 
|   362 |         mvwprintw(win, 0, 1, name); 
|       |         ^~~~~~~~~ 
| cc1: some warnings being treated as errors 
| make: *** [<builtin>: jesd_status.o] Error 1 
| ERROR: oe_runmake failed
```