### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Build and Deploy JESD Eye Scan GTK
+permissions:
+  contents: read
 
 env:
   MAJOR: 0 


### PR DESCRIPTION
Potential fix for [https://github.com/analogdevicesinc/jesd-eye-scan-gtk/security/code-scanning/2](https://github.com/analogdevicesinc/jesd-eye-scan-gtk/security/code-scanning/2)

The best way to fix the problem is to add a `permissions` block that explicitly sets the minimum required permissions for the workflow. Since the jobs shown only check out code and upload artifacts, `contents: read` is sufficient and follows the principle of least privilege. The change should be made at the workflow level (top-level of the YAML), right after the `name:` declaration and before `env:` or `on:`, to ensure all jobs inherit these restricted permissions by default. No additional methods or tools are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
