### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Build and Deploy JESD Eye Scan GTK
+permissions:
+  contents: read
 
 env:
   MAJOR: 0 


### PR DESCRIPTION
Potential fix for [https://github.com/analogdevicesinc/jesd-eye-scan-gtk/security/code-scanning/1](https://github.com/analogdevicesinc/jesd-eye-scan-gtk/security/code-scanning/1)

To address this issue, explicitly set a `permissions` block at either the root of the workflow (recommended for simple cases), or at each individual job (if different jobs have different permission requirements). For this workflow, adding `permissions: contents: read` at the root is sufficient, as all steps and jobs only require basic, minimal permissions—none need to write to contents, issues, or other objects. This setting will restrict the GITHUB_TOKEN’s power to the least privilege required for this workflow.

**Files/regions/lines to change:**  
- Edit `.github/workflows/build.yml` at the root, immediately after the `name:` field (before `env:`), to add:

```yaml
permissions:
  contents: read
```

No extra imports, definitions, or methods are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
