### PR TITLE
jesd_common: preserve device count when opendir fails

### DIFF
--- a/jesd_common.c
+++ b/jesd_common.c
@@ -46,7 +46,7 @@ int jesd_find_devices(const char *basedir, const char *driver, const char *file_
 	dr = opendir(path);
 	if (dr == NULL) {
 		fprintf(stderr, "Could not open current directory\n");
-		return 0;
+		return num;
 	}
 
 	while ((de = readdir(dr)) != NULL) {


### PR DESCRIPTION
## Summary
- Fix `jesd_find_devices()` to return the already-accumulated count instead of `0` when `opendir()` fails during a recursive scan, so devices found earlier in the traversal aren't discarded.

## Test plan
- [ ] Build with cmake on a system with the relevant sysfs layout and confirm no regression.
- [ ] Verify on a system where one subdirectory under the scan root is unreadable: previously-found devices should still be reported.